### PR TITLE
Fix security flaw - prevents people from getting every blocks

### DIFF
--- a/src/redsgreens/SupplySign/SupplySignBlockListener.java
+++ b/src/redsgreens/SupplySign/SupplySignBlockListener.java
@@ -112,7 +112,8 @@ public class SupplySignBlockListener extends BlockListener {
 		try
 		{
 			// only proceed if it's a new sign
-			if (event.getLine(0).equalsIgnoreCase("[Supply]"))
+			if (event.getLine(0).equalsIgnoreCase("[Supply]") ||
+				event.getLine(0).equalsIgnoreCase("§1[Supply]"))
 			{
 				// and they have create permission
 				if (Plugin.isAuthorized(event.getPlayer(), "create")){


### PR DESCRIPTION
Fix when user places a sign starting with &1[Supply] so it verifies permission.

It might be a plugin conflict. At the moment, any player even those without permissions can type &1[Supply] and it will turn into a working sign. This commit fixes that by verifying permission for &1[Supply] too.
