### PR TITLE
Fixed typo - missing dot in permission

### DIFF
--- a/src/main/java/redsgreens/SupplySign/SupplySign.java
+++ b/src/main/java/redsgreens/SupplySign/SupplySign.java
@@ -103,7 +103,7 @@ public class SupplySign extends JavaPlugin {
     
     // return true if Player p has the permission perm
     public boolean isAuthorized(Player player, String perm){
-    	return player.isOp() || (Config.AllowNonOpAccess && perm.equalsIgnoreCase("access")) || player.hasPermission("supplysign" + perm); 
+    	return player.isOp() || (Config.AllowNonOpAccess && perm.equalsIgnoreCase("access")) || player.hasPermission("supplysign." + perm); 
     }
     
     public void onDisable() {


### PR DESCRIPTION
Would cause the permission to be supplysignaccess for example.